### PR TITLE
#8 formatted the output of cpu-temperature script

### DIFF
--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
+inputInMilli=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
 
-# Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
-#
-# Celcius: 42.0 C
-# Fahrenheit: 107.6 F
+tempInCelcius=$((inputInMilli/1000))
+tempInFarenheit=$(((tempInCelcius * 9)/5 + 32))
+
+echo "Celsius: $tempInCelcius C"
+echo "Fahrenheit: $tempInFarenheit F"


### PR DESCRIPTION
This pull request updates the output format of temperature values from milli-celsius to Celsius and Fahrenheit. 
With this change, the temperature values are converted to Celsius and Fahrenheit, providing a more intuitive and user-friendly output format.

Changes Made:
1.   Updated the conversion logic to calculate temperature values in Celsius and Fahrenheit.
2.   Updated the output format to display temperature values in Celsius and Fahrenheit.