### PR TITLE
 # 8 CPU-temperature to celsius and fahrenheit

### DIFF
--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -6,3 +6,9 @@ grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | 
 #
 # Celcius: 42.0 C
 # Fahrenheit: 107.6 F
+
+temp_input=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
+temp_c=$(echo "scale=1; $temp_input / 1000" | bc)
+temp_f=$(echo "scale=1; $temp_c * 9 / 5 + 32" | bc)
+echo "Celcius: $temp_c C"
+echo "Fahrenheit: $temp_f F"

--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -10,5 +10,3 @@ grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | 
 temp_input=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
 temp_c=$(echo "scale=1; $temp_input / 1000" | bc)
 temp_f=$(echo "scale=1; $temp_c * 9 / 5 + 32" | bc)
-echo "Celcius: $temp_c C"
-echo "Fahrenheit: $temp_f F"

--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
-
+#grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
 # Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
 #
 # Celcius: 42.0 C
@@ -10,3 +8,5 @@ grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | 
 temp_input=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
 temp_c=$(echo "scale=1; $temp_input / 1000" | bc)
 temp_f=$(echo "scale=1; $temp_c * 9 / 5 + 32" | bc)
+echo "Celcius: $temp_c C"
+echo "Fahrenheit: $temp_f F"


### PR DESCRIPTION
Fixed #8 

This pull request consist the bash script to convert temperature from millicelsius to celsius and fahrenheit, as they are more commonly used temperature scales.
I have used basic calculator(bc) command to solve the problem.