### PR TITLE
#4 Deleting all binary files

### DIFF
--- a/scripts/rm-bins
+++ b/scripts/rm-bins
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-# Remove all the binary files (usually made after gcc) present inside current directory
-# Refer "man find" for more information, you can also use modern tool like fd instead of find
+# Remove all binary files in the current directory
+find . -type f -executable -exec file {} \; | grep -i 'executable' | cut -d: -f1 | xargs rm -f
+echo "All binary files in the current directory removed successfully"


### PR DESCRIPTION

![Screenshot 2024-03-15 023635](https://github.com/iiitl/bash-practice-repo-24/assets/143875739/c04061a2-6c55-48ee-a6ee-45360c42ac08)
Fixes #4 
This script removes all binary files in the current directory by finding executable files, filtering out binaries, and deleting them. It ensures a clean-up of files typically generated by compilation commands like GCC.