### PR TITLE
Added script for wifi-ssid

### DIFF
--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,11 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+
+#used command iw dev and found out that only wlo1 lan interface was present
+#used this wlo1 interface instead of wlan0
+
+ssid=$(iw dev wlo1 link | grep -oP "(?<=SSID: ).*")
+
+# Print the extracted SSID
+echo "Wi-Fi SSID: $ssid"


### PR DESCRIPTION
 #1
@umeshSinghVerma kindly look into this
**Added script for wifi-ssid**
The script extracts the wifi username (SSID)
Used wlo1 lan interface instead of wlan0 interface.

The output by running the bash script is shown in below image:
![image](https://github.com/iiitl/bash-practice-repo-24/assets/143310797/5e51ab36-662a-4442-bdc5-c40bd5baebbd)




