### PR TITLE
Wrote wifi-ssid script. #1

### DIFF
--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,6 +2,6 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
-SSID=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk '/ SSID:/ {print substr($0, index($0, $2))}')
+SSID=$(networksetup -getairportnetwork en0 | awk -F': ' '/Current Wi-Fi Network:/ {print $2}')
 
 echo "Currently connected Wi-Fi SSID: $SSID"

--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,6 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+SSID=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk '/ SSID:/ {print substr($0, index($0, $2))}')
+
+echo "Currently connected Wi-Fi SSID: $SSID"


### PR DESCRIPTION
I have written a simple Bash script that can be used on a macOS system to extract the SSID (Wi-Fi username) of the currently connected Wi-Fi network.

@umeshSinghVerma kindly look this PR


![image](https://github.com/iiitl/bash-practice-repo-24/assets/143374984/0f8bd441-c897-4888-a0cc-de19b18f8982)
