### PR TITLE
Added code for converting temperature to celcius and fahrenheit.

### DIFF
--- a/scripts/color
+++ b/scripts/color
@@ -10,12 +10,6 @@ declare -A color_mapping=(
     # TODO: Add more color values
     # Refer bash color codes
     ['magenta']=35
-    ['red']=31
-    ['green']=32
-    ['yellow']=33
-    ['blue']=34
-    ['cyan']=36
-    ['white']=37
 )
 
 if [[ $1 == 'reset' ]]; then

--- a/scripts/color
+++ b/scripts/color
@@ -10,6 +10,12 @@ declare -A color_mapping=(
     # TODO: Add more color values
     # Refer bash color codes
     ['magenta']=35
+    ['red']=31
+    ['green']=32
+    ['yellow']=33
+    ['blue']=34
+    ['cyan']=36
+    ['white']=37
 )
 
 if [[ $1 == 'reset' ]]; then

--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
+grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat | awk '{printf "Celcius: %.1f C\nFahrenheit: %.1f F\n", $1 / 1000, ($1 / 1000) * 9 / 5 + 32}'
 
 # Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
 #


### PR DESCRIPTION
addressed issue #8 
The `awk` command takes the input (CPU temperature in millidegree Celsius) and converts it to Celsius and Fahrenheit using the provided formulas. It then prints the results in the specified format with one decimal place.
I have attached the screenshot for the reference.
<img width="833" alt="Screenshot 2024-03-15 at 4 27 04 PM" src="https://github.com/iiitl/bash-practice-repo-24/assets/143504391/2ae24d09-845b-450f-871d-4056956b8b9f">
