### PR TITLE
feature added 'rm-gitignore'

### DIFF
--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+git_repos=$(find . -name .git -type d -prune)
+for repo in $git_repos; do
+    cd "$repo/.." 
+    git clean -xdf
+done
 
-# Removes all files written in .gitignore of any git repository (multiple) present inside current directory
-# To find list of all git repos inside current directory you can use: "find . -name .git -type d -prune"

--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -1,6 +1,6 @@
 git_repos=$(find . -name .git -type d -prune)
 for repo in $git_repos; do
     cd "$repo/.." 
-    git clean -xdf
+    git clean -Xdf
 done
 


### PR DESCRIPTION
Fixes #3 
This pull request adds a script that uses `find` to locate all Git repositories within a directory and its subdirectories. It then iterates over each repository, changing into the repository's parent directory, and running `git clean -Xdf` to remove untracked files and directories.

