### PR TITLE
Write rm-gitignore script. #3

### DIFF
--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -1,4 +1,26 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-# Removes all files written in .gitignore of any git repository (multiple) present inside current directory
-# To find list of all git repos inside current directory you can use: "find . -name .git -type d -prune"
+# Find all Git repositories in the current directory
+git_repos=$(find . -name .git -type d -prune)
+
+# Iterate over each Git repository
+for repo in $git_repos; do
+    # Navigate to the root directory of the repository
+    repo_dir=$(dirname "$repo")
+    cd "$repo_dir" || continue
+
+    # Check if .gitignore file exists
+    if [ -f .gitignore ]; then
+        echo "Removing files specified in .gitignore for repository: $repo_dir"
+        # Read .gitignore and remove specified files
+        while IFS= read -r pattern; do
+            # Use find command to remove files matching patterns in .gitignore
+            find . -path "./$pattern" -type f -delete
+        done < .gitignore
+    else
+        echo "No .gitignore file found for repository: $repo_dir"
+    fi
+
+    # Return to the original directory
+    cd - >/dev/null || exit
+done


### PR DESCRIPTION
This pull request #3 addresses the issue [#3], which involves creating a script to remove all files specified in the .gitignore files located at the root of each Git repository found within the current directory.

Changes Made:

Created a Bash script named `rm-gitignore` to automate the process.
Utilized the find command to locate all Git repositories within the current directory.
Implemented a loop to iterate over each repository and navigate to its root directory.
Checked for the existence of a .gitignore file in each directory.
If a .gitignore file was found, read its contents and used the find command to remove files specified in it.
Displayed appropriate messages to indicate the progress and status of the script execution.