### PR TITLE
feature added password-generator

### DIFF
--- a/scripts/password-generator
+++ b/scripts/password-generator
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 length=$(shuf -i 7-10 -n 1)
-password=$(tr -dc 'A-Za-z0-9!?%@47*=' < /dev/urandom | head -c $length)
+password=$(tr -dc 'A-Za-z0-9!?%@$&*=' < /dev/urandom | head -c $length)
 echo "$password"

--- a/scripts/password-generator
+++ b/scripts/password-generator
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-# Issue: Implement Password Generation Functions
-# Description:
-# Create a function that generates passwords, The password should consist of uppercase letters, lowercase letters, numbers, and special characters. The function should take in a single argument, which is the length of the password to generate. The function should return the generated password.
+length=$(shuf -i 7-10 -n 1)
+password=$(tr -dc 'A-Za-z0-9!?%@47*=' < /dev/urandom | head -c $length)
+echo "$password"


### PR DESCRIPTION
fixes #5 
In this PR, i wrote a script a random password using `shuf` , `tr` , `/dev/urandom` and `head`

Implementation:

- `shuf` to generate random length of password, `-i` decides range and '-n' picks out given number of elements

- `tr -dc 'A-Za-z0-9!?%@$&*=` `< /dev/urandom` 
This command reads random bytes from `/dev/urandom` and filters them through `tr` to keep only characters that are alphanumeric (A-Za-z0-9) or in the set `!?%@$&*=` The -d option deletes characters not in the specified set, and -c complements the set (i.e., keeps only the specified characters).

- `head -c $length` 
This limits the output of tr to the first `length` characters, effectively creating a random password of length.