### PR TITLE
Code for extracting the wifi username

### DIFF
--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,9 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+ssid=$(iw dev wlan0 link | awk '/SSID/ {print $2}')
+if [ -n "$ssid" ]; then
+    echo "WiFi SSID: $ssid"
+else
+    echo "WiFi SSID not available"
+fi


### PR DESCRIPTION
Solved the issue #1 

This pull request addresses an issue to output the Wi-Fi SSID correctly. 

###Code Implemented:

- Used the command sequence to extract the SSID from the `iw dev wlan0 link` command output accurately.
- Utilized `awk` to extract the SSID field directly from the command output, improving simplicity and reliability.
- Added error handling to gracefully handle scenarios where the Wi-Fi SSID is not available or the `iw` command fails.
