### PR TITLE
Removes all files written in .gitignore of any git repo

### DIFF
--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -8,7 +8,7 @@ find . -name .git -type d -prune | while read -r git_dir; do
     if [ -f .gitignore ]; then
         while IFS= read -r pattern; do
             echo "Removing files matching pattern: $pattern"
-            git ls-files --ignored --exclude-standard | grep "$pattern" | xargs -I {} rm -f {}
+            git ls-files --cached --ignored --exclude-standard | grep "$pattern" | xargs -I {} rm -f {}
         done < .gitignore
     fi
 

--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -2,3 +2,15 @@
 
 # Removes all files written in .gitignore of any git repository (multiple) present inside current directory
 # To find list of all git repos inside current directory you can use: "find . -name .git -type d -prune"
+find . -name .git -type d -prune | while read -r git_dir; do
+    cd "$git_dir/.."
+
+    if [ -f .gitignore ]; then
+        while IFS= read -r pattern; do
+            echo "Removing files matching pattern: $pattern"
+            git ls-files --ignored --exclude-standard | grep "$pattern" | xargs -I {} rm -f {}
+        done < .gitignore
+    fi
+
+    cd -
+done


### PR DESCRIPTION
Solved issue #3 ,

This pull request enhances the existing Gitignore cleanup script to improve efficiency and usability. The script now accurately removes files specified in the `.gitignore` files of Git repositories found within the current directory and its subdirectories.

Please review and merge at your earliest convenience.