### PR TITLE
Remove all the binary files

### DIFF
--- a/scripts/rm-bins
+++ b/scripts/rm-bins
@@ -2,3 +2,4 @@
 
 # Remove all the binary files (usually made after gcc) present inside current directory
 # Refer "man find" for more information, you can also use modern tool like fd instead of find
+find . -type f -executable -exec file {} \; | grep "executable" | cut -d':' -f1 | xargs rm -f

--- a/scripts/rm-bins
+++ b/scripts/rm-bins
@@ -2,4 +2,4 @@
 
 # Remove all the binary files (usually made after gcc) present inside current directory
 # Refer "man find" for more information, you can also use modern tool like fd instead of find
-find . -type f -executable -exec file {} \; | grep "executable" | cut -d':' -f1 | xargs rm -f
+find . -type f -executable -exec file {} \; | grep "ELF" | cut -d':' -f1 | xargs rm -f


### PR DESCRIPTION
Solved the issue #4 

The  script finds all executable files within the current directory using the `find` command. It then filters the output to include only binary executable files using `grep`. Finally, it extracts the file paths and removes them using `xargs rm -f`.