### PR TITLE
#8 Formatted the output of CPU temperature script 

### DIFF
--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
+
 
 # Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
 #
 # Celcius: 42.0 C
 # Fahrenheit: 107.6 F
+
+temp_milidegree=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
+temp_celcius=$(echo "scale=1; $temp_milidegree / 1000" | bc)
+temp_fahrenheit=$(echo "scale=1; ($temp_celcius * 9/5) + 32" | bc)
+
+echo "Celcius:" $temp_celcius "C"
+echo "Fahrenheit:" $temp_fahrenheit "F"


### PR DESCRIPTION
Fixes #8
**Formatted the output of CPU temperature script** 

Output when we run the script
**Command Used**
`bash cpu-temperature`
![image](https://github.com/iiitl/bash-practice-repo-24/assets/143310797/1f74a955-9f69-40f6-8c95-98848884fecd)

**Changes made**
Stored the temperature in milidegree-celsius in a variable and performed the desired arithmetic to convert them to Celsius and 
Fahrenheit respectively and then displayed them in desired format.
