### PR TITLE
added feature: Music extractor

### DIFF
--- a/scripts/music-extract
+++ b/scripts/music-extract
@@ -1,28 +1,26 @@
 #!/usr/bin/env bash
 
-# TODO: Make a ffmpeg script which takes all the mp4 files in a folder (recursively) and output them in the same position mp3 file
-#
-# E.g.:
-# Videos
-# ├── Clips
-# │   ├── clip1.mp4
-# │   └── clip2.mp4
-# ├── Movies
-# │   ├── movie1.mp4
-# │   └── movie2.mp4
-# └── Songs
-#     ├── Song1.mp4
-#     └── Song2.mp4
-# music-extract Videos
-#
-# The above folder will create another folder with the position of file with just there audio
-# Music
-# ├── Clips
-# │   ├── clip1.mp3
-# │   └── clip2.mp3
-# ├── Movies
-# │   ├── movie1.mp3
-# │   └── movie2.mp3
-# └── Songs
-#     ├── Song1.mp3
-#     └── Song2.mp3
+output_dir="$(pwd)/Music"
+
+fd . -e 'mp4' | while read -r file; do
+
+    filename_no_ext="${file%.*}" # clips/Sequence04
+    # echo "$filename_no_ext"
+    filename_with_ext="${file}" #clips/Sequence04.mp4
+    # echo "$filename_with_ext"
+
+    output_file="${output_dir}/${filename_no_ext}"
+
+    #making corresponding folders here
+    dir_name=$(dirname "$filename_with_ext") # clips
+    # echo "$dir_name"
+    mkdir -p "$output_dir/$dir_name" #makes pwd/music/clips
+
+    input="$(pwd)/$filename_with_ext" # /home/baka/Pictures/clips/Sequence04.mp4
+    output="${output_file}.mp3"       # /home/baka/Pictures/Music/clips/Sequence04.mp3
+
+    # echo "$output"
+
+    ffmpeg -i "$input" "$output"
+
+done


### PR DESCRIPTION
This script is designed to convert all .mp4 files in the current directory and its subdirectories into .mp3 files and store them in the Music directory. Here's a breakdown of the implementation:

-     `output_dir="$(pwd)/Music"` : 
       Defines the output directory as Music within the current directory.

-     `fd . -e 'mp4'` : 
       This command finds all files (fd) in the current directory (.) and its subdirectories that have the .mp4 extension.

-     `while read -r file; do ... done`:
       Loops through each found .mp4 file.

-     `filename_no_ext="${file%.*}"`: 
       Extracts the filename without the extension. For example, clips/Sequence04.

-     `filename_with_ext="${file}"`: 
       Stores the filename with the extension. For example, clips/Sequence04.mp4.

-     `output_file="${output_dir}/${filename_no_ext}"`:
       Defines the output file path, including the output directory and filename without extension. 
       For example, Pictures/Music/clips/Sequence04.

-     `dir_name=$(dirname "$filename_with_ext")`:
       Extracts the directory name. For example, clips.

-     `mkdir -p "$output_dir/$dir_name"`: 
       Creates the corresponding directory in the Music directory. For example, Pictures/Music/clips.

-    ` input="$(pwd)/$filename_with_ext"`: 
      Defines the input file path. For example, /home/baka/Pictures/clips/Sequence04.mp4.

-     `output="${output_file}.mp3"`: 
       Defines the output file path with the .mp3 extension. For example, /home/baka/Pictures/Music/clips/Sequence04.mp3.

-     `ffmpeg -i "$input" "$output"`:
      Uses ffmpeg to convert the .mp4 file to .mp3 and save it in the specified output directory.

Overall, the script finds all .mp4 files, creates the corresponding directories in the Music directory, and then converts each .mp4 file to .mp3, storing them in the Music directory.
