### PR TITLE
#6 Added perms script

### DIFF
--- a/scripts/perms
+++ b/scripts/perms
@@ -7,3 +7,22 @@
 # 775 weather
 # 664 ../README.md
 
+
+
+if [ $# -eq 0 ]; then
+    echo "Kindly add file names in arguments too...."
+    exit 1
+fi  
+
+list_permissions() {
+    for file in "$@"; do
+        if [ -e "$file" ]; then
+            permissions=$(stat -c "%a" "$file")
+            echo "Permissions of '$file' in octal format: $permissions"
+        else
+            echo "File '$file' does not exist."
+        fi
+    done
+}
+
+list_permissions "$@"


### PR DESCRIPTION
Fixes #6 
**Added the perms script**

This script takes a certain set of filenames as input and displays their permission in octal format if they exist.

OUTPUT 
_**Commands used**_
`ls -a`
`bash perms <filename1> <filename2> <filename3>......`
![image](https://github.com/iiitl/bash-practice-repo-24/assets/143310797/2494a855-b5be-48b8-97a2-5cad5fe6afbb)

_**Command used**_
`bash perms`
![image](https://github.com/iiitl/bash-practice-repo-24/assets/143310797/d91aa13b-9970-442b-9417-515f0e6b74ee)

**Explanation of the code**

` for file in "$@"; do`
Checks for all the files given in arguments

`if [ -e "$file" ]; then`
Checks for existence of the file in the present working directory

` permissions=$(stat -c "%a" "$file")`
Retrieves the permissions of a file and assigns them to the variable permissions. 

`echo "Permissions of '$file' in octal format: $permissions"`
Displays the permissions of the file in octal format

` echo "File '$file' does not exist."`
If the file is not present in the present working directory then displays that Fille does not exist

`list_permissions "$@"`
Calls the list_permission function

**Explanation of the Output**
If the script displays the permissions as 775 that means

- The first digit (7) represents the permissions for the owner. In octal, 7 means read (4) + write (2) + execute (1), which means the owner has read, write, and execute permissions.

- The second digit (7) represents the permissions for the group. Again, 7 means read (4) + write (2) + execute (1), which means the group has read, write, and execute permissions.

- The third digit (5) represents the permissions for others. 5 means read  (4) + execute (1), which means others have read and execute permissions but not write permissions.