### PR TITLE
#75 Added script to count lines in remote repository

### DIFF
--- a/scripts/gitlines
+++ b/scripts/gitlines
@@ -2,3 +2,21 @@
 
 # TODO: Display lines of code by language in a remote git repository
 # Refer "cloc" command or similar
+#!/usr/bin/env bash
+
+
+if [ "$#" -eq 0 ]; then
+    echo "Kindly also pass the repository url for which you want to count the lines"
+    exit 1
+fi
+
+repo_url=$1
+cd ..
+
+temporary_directory=$(mktemp -d)
+git clone "$repo_url" "$temporary_directory"
+
+cd "$temporary_directory" || exit
+cloc $temporary_directory
+
+rm -rf "$temporary_directory"


### PR DESCRIPTION
Fixes #75 
Added script that count lines in remote repository

**OUTPUT**
**Command Used**
`bash gitlines <repo_url>`
![image](https://github.com/iiitl/bash-practice-repo-24/assets/143310797/225c6875-cf34-44b4-a4ad-05e7f8e6c59c)

**Command Used**
`bash gitlines`
![image](https://github.com/iiitl/bash-practice-repo-24/assets/143310797/8bb58b87-f9ec-43a2-a0b2-572d6928c417)

**EXPLANATION OF CODE**
`if [ "$#" -eq 0 ]; then`
Checks if no argument is passed then asks user to enter the repository name as argument 

`repo_url=$1`
Stores the URL passed into the a variable named `repo_url`

`temporary_directory=$(mktemp -d)`
Creates a temporary directory and stores it in the variable named `temporary_directory`

`git clone "$repo_url" "$temporary_directory"`
Clones the given repository into the local system inside the temporary directory we created

`cd "$temporary_directory" || exit`
Changes the present working directory into temporary directory

`cloc $temporary_directory`
This command allows user to count no. of lines in the directory and displays them into the terminal according to the programming language

`rm -rf "$temporary_directory"`
Removes the directory to prevent the storage from getting full. `rm -rf` is used to forcefully remove the files and folders.