### PR TITLE
Format the output of cpu-temperature script.

### DIFF
--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
+# grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
 
 # Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
 #
 # Celcius: 42.0 C
 # Fahrenheit: 107.6 F
+
+temp_mk=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
+
+# Convert the temperature to Celsius
+temp_c=$(echo "scale=2; $temp_mk / 1000" | bc)
+
+# Convert the temperature to Fahrenheit
+temp_f=$(echo "scale=2; $temp_c * 9 / 5 + 32" | bc)
+
+echo "Celsius: $temp_c C"
+echo "Fahrenheit: $temp_f F"


### PR DESCRIPTION
Hey @rootCircle, I've formated the output for the cput-temperature file and modified it to show temperature in both Celsius and Fahrenheit.
fixes #8 
Thanks 
![image](https://github.com/iiitl/bash-practice-repo-24/assets/98659780/cd568a7c-7e10-42de-897c-717aef49cbd2)
