### PR TITLE
Write gitlines script.

### DIFF
--- a/scripts/gitlines
+++ b/scripts/gitlines
@@ -2,3 +2,38 @@
 
 # TODO: Display lines of code by language in a remote git repository
 # Refer "cloc" command or similar
+
+check_cloc() {
+    command -v cloc >/dev/null 2>&1 || { echo >&2 "cloc is required but not installed. Aborting."; exit 1; }
+}
+
+get_lines_of_code() {
+    local repository=$1
+
+    local temp_dir=$(mktemp -d)
+    git clone "$repository" "$temp_dir" >/dev/null 2>&1 || { echo >&2 "Failed to clone the repository. Aborting."; exit 1; }
+
+    cloc "$temp_dir"
+
+    rm -rf "$temp_dir"
+}
+
+main() {
+    check_cloc
+
+    if [ $# -ne 1 ]; then
+        echo "Usage: $0 <repository_url>"
+        exit 1
+    fi
+
+    local repository_url=$1
+
+    get_lines_of_code "$repository_url"
+}
+
+main "$@"
+
+# First you have to install cloc
+# 
+# Example execution:
+# ./gitlines.sh https://github.com/username/repository.git


### PR DESCRIPTION
Fixes issue #75 
Added the script to get the lines of code filtered by the language from a remote git repository.

# Changes Made:
- Added a Bash script to gitlines.sh
- The script utilizes the `cloc` tool to analyze a remote Git repository and generate a report of lines of code by language.
- The script prompts the user to input the URL of the remote Git repository and then generates the code analysis report.
- Added instructions on how to use the script:
> Users should execute the script by providing the URL of the remote Git repository as an argument.
> Example usage is provided in the comments within the 

# Additional Notes:
- The script provides a simple and automated way to analyze code in remote Git repositories, aiding in understanding codebase structure and complexity.
- Tested the script to ensure proper functionality.
![image](https://github.com/iiitl/bash-practice-repo-24/assets/98659780/c75c3e68-8936-4ac2-8a4b-8ec625ee7220)
