### PR TITLE
Implemented music-extract

### DIFF
--- a/scripts/music-extract
+++ b/scripts/music-extract
@@ -26,3 +26,34 @@
 # └── Songs
 #     ├── Song1.mp3
 #     └── Song2.mp3
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <videos_folder>"
+    exit 1
+fi
+
+videos_folder="$1"
+
+if [ ! -d "$videos_folder" ]; then
+    echo "Videos folder not found!"
+    exit 1
+fi
+
+videos_folder=$(realpath "$videos_folder")
+
+output_folder="${videos_folder}_extracted_audio"
+mkdir -p "$output_folder"
+
+find "$videos_folder" -type f -name "*.mp4" | while read -r video_file; do
+    # Extract the filename and directory of the video file
+    file_name=$(basename "$video_file")
+    dir_name=$(dirname "$video_file")
+    
+    output_file="$output_folder/${file_name%.mp4}.mp3"
+    
+    ffmpeg -i "$video_file" -vn -acodec libmp3lame -q:a 2 "$output_file"
+    
+    echo "Extracted audio from $video_file to $output_file"
+done
+
+echo "Process finished."


### PR DESCRIPTION
FIXES #91 

Wrote a simple bash script to extract the music from videos in a particular directory and store the resulting audio in another directory mirroring the original file hierarchy.
The script simply stores the path to the videos folder provided in a variable and converts it into absolute path. Further, it constructs the path of the output folder to store the extracted audio.

**Audio Extraction**
- First, the code recursively searches through the directory to find all mp4 files in the folder.
- Next constructs the path for the output.
- The audio extraction part is performed by the 'ffmpeg' command, and encoded using the mp3 codec "libmp3lame".
- Lastly, on completion of the process, it prints a message indicating that the process has finished.



![Screenshot 2024-03-18 011003](https://github.com/iiitl/bash-practice-repo-24/assets/143324730/38b9a727-37c7-489d-a784-4090cd583c0c)

<img width="931" alt="Screenshot 2024-03-18 011028" src="https://github.com/iiitl/bash-practice-repo-24/assets/143324730/27c3e98c-8d51-4bcc-b004-2608172bc906">

@rootCircle kindly review.